### PR TITLE
update angular sdk to support 1.0.0 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import { BerbixComponent } from "berbix-angular";
   declarations: [AppComponent, BerbixComponent],
   imports: [BrowserModule],
   providers: [],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
 export class AppModule {}
 ```
@@ -45,11 +45,16 @@ Now you can use the `lib-berbix` component in your templates.
 // Required
 @Input() clientToken: string;
 
+// Optional
+@Input() showInModal: boolean;
+@Input() showCloseModalButton: boolean;
+
 // Event emitters
-@Output() flowCompleted = new EventEmitter<FlowCompletedEvent>();
+@Output() flowCompleted = new EventEmitter<void>();
 @Output() flowError = new EventEmitter<object>();
-@Output() flowDisplayed = new EventEmitter<any>();
+@Output() flowDisplayed = new EventEmitter<void>();
 @Output() flowStateChange = new EventEmitter<object>();
+@Output() flowExit = new EventEmitter<void>();
 ```
 
 ## Publishing

--- a/package-lock.json
+++ b/package-lock.json
@@ -14585,9 +14585,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "@angular/cli": "10.0.0",
     "@angular/compiler-cli": "8.2.14",
     "@angular/language-service": "8.2.14",
-    "@types/node": "8.10.59",
     "@types/jasmine": "3.5.11",
     "@types/jasminewd2": "2.0.8",
+    "@types/node": "8.10.59",
     "codelyzer": "5.2.2",
     "jasmine-core": "3.5.0",
     "jasmine-spec-reporter": "5.0.2",
@@ -45,6 +45,6 @@
     "ts-node": "8.10.2",
     "tsickle": "0.38.1",
     "tslint": "5.20.1",
-    "typescript": "3.9.5"
+    "typescript": "^3.5.3"
   }
 }

--- a/projects/berbix/src/lib/berbix.component.ts
+++ b/projects/berbix/src/lib/berbix.component.ts
@@ -49,6 +49,7 @@ export class BerbixComponent implements OnInit, OnDestroy {
 
   show = true;
   height = 0;
+  marginTop = 0;
   idx = 0;
   frameUrl: SafeResourceUrl;
 
@@ -89,6 +90,7 @@ export class BerbixComponent implements OnInit, OnDestroy {
     } else if (data.type === "DISPLAY_IFRAME") {
       flowDisplayed.emit(null);
       this.height = data.payload.height;
+      this.marginTop = data.payload.margin || 0;
     } else if (data.type === "RESIZE_IFRAME") {
       this.height = data.payload.height;
     } else if (data.type === "RELOAD_IFRAME") {
@@ -150,6 +152,11 @@ export class BerbixComponent implements OnInit, OnDestroy {
     if (token) {
       options.push("client_token=" + token);
     }
+    const height = Math.max(
+      document.documentElement.clientHeight,
+      window.innerHeight || 0
+    );
+    options.push("max_height=" + height);
     return this.sanitizer.bypassSecurityTrustResourceUrl(
       this.getBaseUrl() + "/" + version + "/verify?" + options.join("&")
     );
@@ -164,6 +171,7 @@ export class BerbixComponent implements OnInit, OnDestroy {
       display: "block",
       width: "100%",
       height: this.height + "px",
+      marginTop: this.marginTop + "px",
       overflow: "hidden",
     };
   }

--- a/projects/berbix/src/lib/berbix.component.ts
+++ b/projects/berbix/src/lib/berbix.component.ts
@@ -9,11 +9,6 @@ import {
 import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
 
 const SDK_VERSION = "0.0.8";
-
-export interface FlowCompletedEvent {
-  code: string;
-}
-
 @Component({
   selector: "lib-berbix",
   template: `
@@ -44,16 +39,15 @@ export class BerbixComponent implements OnInit, OnDestroy {
   @Input() baseUrl: string;
   @Input() overrideUrl: string;
   @Input() version = "v0";
-  @Input() continuation: string;
   @Input() clientToken: string;
   @Input() showInModal: boolean;
   @Input() showCloseModalButton: boolean;
 
-  @Output() flowCompleted = new EventEmitter<FlowCompletedEvent>();
+  @Output() flowCompleted = new EventEmitter<void>();
   @Output() flowError = new EventEmitter<object>();
-  @Output() flowDisplayed = new EventEmitter<any>();
+  @Output() flowDisplayed = new EventEmitter<void>();
   @Output() flowStateChange = new EventEmitter<object>();
-  @Output() flowExit = new EventEmitter<any>();
+  @Output() flowExit = new EventEmitter<void>();
 
   show = true;
   height = 0;
@@ -93,7 +87,7 @@ export class BerbixComponent implements OnInit, OnDestroy {
     if (data.type === "VERIFICATION_COMPLETE") {
       try {
         if (data.payload.success) {
-          flowCompleted.emit({ code: data.payload.code });
+          flowCompleted.emit(null);
         } else {
           flowError.emit(data);
         }
@@ -132,7 +126,6 @@ export class BerbixComponent implements OnInit, OnDestroy {
     const {
       overrideUrl,
       version,
-      continuation,
       clientToken,
       showInModal,
       showCloseModalButton,
@@ -140,7 +133,7 @@ export class BerbixComponent implements OnInit, OnDestroy {
     if (overrideUrl != null) {
       return overrideUrl;
     }
-    const token = clientToken || continuation;
+    const token = clientToken;
     var options = ["sdk=BerbixAngular-" + SDK_VERSION];
     if (token) {
       options.push("client_token=" + token);

--- a/projects/berbix/src/lib/berbix.component.ts
+++ b/projects/berbix/src/lib/berbix.component.ts
@@ -17,12 +17,12 @@ export interface FlowCompletedEvent {
 @Component({
   selector: "lib-berbix",
   template: `
-    <ng-container [ngIf]="show">
+    <ng-container *ngIf="show">
       <div *ngIf="showInModal; else frameTpl">
-        [ngStyle]="outerDivStyles()"
-        <div>
-          [ngStyle]="innerDivStyles()"
-          <ng-container *ngTemplateOutlet="frameTpl"></ng-container>
+        <div [ngStyle]="outerDivStyles()">
+          <div [ngStyle]="innerDivStyles()">
+            <ng-container *ngTemplateOutlet="frameTpl"></ng-container>
+          </div>
         </div>
       </div>
     </ng-container>
@@ -41,18 +41,13 @@ export interface FlowCompletedEvent {
   styles: [],
 })
 export class BerbixComponent implements OnInit, OnDestroy {
-  @Input() clientId: string;
-  @Input() role: string;
-  @Input() templateKey: string;
   @Input() baseUrl: string;
-  @Input() environment: string;
   @Input() overrideUrl: string;
   @Input() version = "v0";
   @Input() continuation: string;
   @Input() clientToken: string;
   @Input() showInModal: boolean;
-  @Input() email: string; // deprecated, do not use
-  @Input() phone: string; // deprecated, do not use
+  @Input() showCloseModalButton: boolean;
 
   @Output() flowCompleted = new EventEmitter<FlowCompletedEvent>();
   @Output() flowError = new EventEmitter<object>();
@@ -126,56 +121,36 @@ export class BerbixComponent implements OnInit, OnDestroy {
   };
 
   getBaseUrl() {
-    const { baseUrl, environment } = this;
+    const { baseUrl } = this;
     if (baseUrl != null) {
       return baseUrl;
     }
-    switch (environment) {
-      case "sandbox":
-        return "https://verify.sandbox.berbix.com";
-      case "staging":
-        return "https://verify.staging.berbix.com";
-      default:
-        return "https://verify.berbix.com";
-    }
+    return "https://verify.berbix.com";
   }
 
   getFrameUrl() {
     const {
       overrideUrl,
       version,
-      clientId,
-      role,
-      templateKey,
-      email,
-      phone,
       continuation,
       clientToken,
       showInModal,
+      showCloseModalButton,
     } = this;
     if (overrideUrl != null) {
       return overrideUrl;
     }
     const token = clientToken || continuation;
-    const template = templateKey || role;
     var options = ["sdk=BerbixAngular-" + SDK_VERSION];
-    if (clientId) {
-      options.push("client_id=" + clientId);
-    }
-    if (template) {
-      options.push("template=" + template);
-    }
-    if (email) {
-      options.push("email=" + encodeURIComponent(email));
-    }
-    if (phone) {
-      options.push("phone=" + encodeURIComponent(phone));
-    }
     if (token) {
       options.push("client_token=" + token);
     }
     if (showInModal) {
-      options.push("modal=true");
+      if (!showCloseModalButton) {
+        options.push("modal=1");
+      } else {
+        options.push("modal=2");
+      }
     }
     const height = Math.max(
       document.documentElement.clientHeight,

--- a/projects/berbix/src/lib/berbix.component.ts
+++ b/projects/berbix/src/lib/berbix.component.ts
@@ -1,14 +1,21 @@
-import { Component, OnInit, OnDestroy, EventEmitter, Input, Output } from '@angular/core';
-import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  EventEmitter,
+  Input,
+  Output,
+} from "@angular/core";
+import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
 
-const SDK_VERSION = '0.0.8';
+const SDK_VERSION = "0.0.8";
 
 export interface FlowCompletedEvent {
   code: string;
 }
 
 @Component({
-  selector: 'lib-berbix',
+  selector: "lib-berbix",
   template: `
     <iframe
       *ngIf="show"
@@ -20,7 +27,7 @@ export interface FlowCompletedEvent {
     >
     </iframe>
   `,
-  styles: []
+  styles: [],
 })
 export class BerbixComponent implements OnInit, OnDestroy {
   @Input() clientId: string;
@@ -29,7 +36,7 @@ export class BerbixComponent implements OnInit, OnDestroy {
   @Input() baseUrl: string;
   @Input() environment: string;
   @Input() overrideUrl: string;
-  @Input() version = 'v0';
+  @Input() version = "v0";
   @Input() continuation: string;
   @Input() clientToken: string;
   @Input() email: string; // deprecated, do not use
@@ -45,18 +52,18 @@ export class BerbixComponent implements OnInit, OnDestroy {
   idx = 0;
   frameUrl: SafeResourceUrl;
 
-  constructor(protected sanitizer: DomSanitizer) { }
+  constructor(protected sanitizer: DomSanitizer) {}
 
   ngOnInit() {
     this.frameUrl = this.getFrameUrl();
-    if (typeof(window) !== 'undefined') {
-      window.addEventListener('message', this.handleMessage);
+    if (typeof window !== "undefined") {
+      window.addEventListener("message", this.handleMessage);
     }
   }
 
   ngOnDestroy() {
-    if (typeof(window) !== 'undefined') {
-      window.removeEventListener('message', this.handleMessage);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("message", this.handleMessage);
     }
   }
 
@@ -68,7 +75,7 @@ export class BerbixComponent implements OnInit, OnDestroy {
     }
 
     const data = JSON.parse(e.data);
-    if (data.type === 'VERIFICATION_COMPLETE') {
+    if (data.type === "VERIFICATION_COMPLETE") {
       try {
         if (data.payload.success) {
           flowCompleted.emit({ code: data.payload.code });
@@ -79,21 +86,21 @@ export class BerbixComponent implements OnInit, OnDestroy {
         // Continue clean-up even if callback throws
       }
       this.show = false;
-    } else if (data.type === 'DISPLAY_IFRAME') {
+    } else if (data.type === "DISPLAY_IFRAME") {
       flowDisplayed.emit(null);
       this.height = data.payload.height;
-    } else if (data.type === 'RESIZE_IFRAME') {
+    } else if (data.type === "RESIZE_IFRAME") {
       this.height = data.payload.height;
-    } else if (data.type === 'RELOAD_IFRAME') {
+    } else if (data.type === "RELOAD_IFRAME") {
       this.height = 0;
       this.idx += 1;
-    } else if (data.type === 'STATE_CHANGE') {
+    } else if (data.type === "STATE_CHANGE") {
       flowStateChange.emit(data.payload);
-    } else if (data.type === 'ERROR_RENDERED') {
+    } else if (data.type === "ERROR_RENDERED") {
       flowError.emit(data.payload);
       this.height = 200;
     }
-  }
+  };
 
   getBaseUrl() {
     const { baseUrl, environment } = this;
@@ -101,53 +108,63 @@ export class BerbixComponent implements OnInit, OnDestroy {
       return baseUrl;
     }
     switch (environment) {
-      case 'sandbox':
-        return 'https://verify.sandbox.berbix.com';
-      case 'staging':
-        return 'https://verify.staging.berbix.com';
+      case "sandbox":
+        return "https://verify.sandbox.berbix.com";
+      case "staging":
+        return "https://verify.staging.berbix.com";
       default:
-        return 'https://verify.berbix.com';
+        return "https://verify.berbix.com";
     }
   }
 
   getFrameUrl() {
-    const { overrideUrl, version, clientId, role, templateKey, email, phone, continuation, clientToken } = this;
+    const {
+      overrideUrl,
+      version,
+      clientId,
+      role,
+      templateKey,
+      email,
+      phone,
+      continuation,
+      clientToken,
+    } = this;
     if (overrideUrl != null) {
       return overrideUrl;
     }
     const token = clientToken || continuation;
     const template = templateKey || role;
-    var options = ['sdk=BerbixAngular-' + SDK_VERSION];
+    var options = ["sdk=BerbixAngular-" + SDK_VERSION];
     if (clientId) {
-      options.push('client_id=' + clientId);
+      options.push("client_id=" + clientId);
     }
     if (template) {
-      options.push('template=' + template);
+      options.push("template=" + template);
     }
     if (email) {
-      options.push('email=' + encodeURIComponent(email));
+      options.push("email=" + encodeURIComponent(email));
     }
     if (phone) {
-      options.push('phone=' + encodeURIComponent(phone));
+      options.push("phone=" + encodeURIComponent(phone));
     }
     if (token) {
-      options.push('client_token=' + token);
+      options.push("client_token=" + token);
     }
     return this.sanitizer.bypassSecurityTrustResourceUrl(
-      (this.getBaseUrl() + '/' + version + '/verify?') + options.join('&'));
+      this.getBaseUrl() + "/" + version + "/verify?" + options.join("&")
+    );
   }
 
   frameStyles() {
     return {
-      backgroundColor: 'transparent',
-      border: '0 none transparent',
+      backgroundColor: "transparent",
+      border: "0 none transparent",
       padding: 0,
       margin: 0,
-      display: 'block',
-      width: '100%',
-      height: this.height + 'px',
-      overflow: 'hidden',
+      display: "block",
+      width: "100%",
+      height: this.height + "px",
+      overflow: "hidden",
     };
   }
-
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,6 @@
         "dist/berbix/*"
       ]
     }
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Adds modal support, modal close support

Removes deprecated features 
- Client-side template seeding
- Client-side email seeding
- Client-side phone seeding
- Client-side client_id seeding
- Client-side passing of authorization_code within onComplete (through the TypeScript definitions)
